### PR TITLE
still segfaulting on AMREuler

### DIFF
--- a/include/amr/Proto_AMRData.H
+++ b/include/amr/Proto_AMRData.H
@@ -34,7 +34,7 @@ namespace Proto
             \param grid     An AMR Grid. Data is allocated only for existing levels
             \param ghost    Specifies the number of ghost cells to allocate
         */
-        AMRData(AMRGrid& a_grid, Point a_ghost) { define (a_grid, a_ghost); }
+        AMRData(AMRGrid a_grid, Point a_ghost) { define (a_grid, a_ghost); }
 
         /// Single Level Constructor
         /**
@@ -70,12 +70,18 @@ namespace Proto
        */
         inline void
         regrid(AMRGrid& a_newgrid, int a_lbase, int a_order);
+
+		/// Grid Access (Const)
+		inline const AMRGrid& grid() const {return m_grid; }
       
-        /// Grid Access (Const)
-        inline const AMRGrid& grid() const {return m_grid; }
-        
         /// Grid Access (Non-Const)
         inline AMRGrid& grid() { return m_grid;}
+      
+        /// Ghost Access (Non-Const)
+        inline Point ghost() const { return m_ghost;}
+
+		/// Data Access (Non-Const)
+        inline std::vector<std::shared_ptr<LevelBoxData<T, C, MEM, CTR>>> data() const { return m_data; }
         
         /// Level Data Access (Const)
         inline const LevelBoxData<T, C, MEM, CTR>&

--- a/include/base/Proto_DisjointBoxLayout.H
+++ b/include/base/Proto_DisjointBoxLayout.H
@@ -102,7 +102,7 @@ namespace Proto
 
           \param a_layout   Another DisjointBoxLayout
         */
-        inline DisjointBoxLayout(const DisjointBoxLayout& a_layout);
+        inline DisjointBoxLayout(const DisjointBoxLayout& a_layout, const bool dev=false);
 
         /// Define (Full Domain)
         /**

--- a/include/base/Proto_HDF5.H
+++ b/include/base/Proto_HDF5.H
@@ -217,11 +217,20 @@ namespace Proto
                         Args... a_params);
 #ifdef PR_AMR 
         /// Write AMR Hierarchy 
-        template<typename T, unsigned int C, MemType MEM, Centering CTR, typename... Args>
+        template<typename T, unsigned int C, Centering CTR, typename... Args>
         inline void writeAMRData(
                         std::vector<std::string> a_varnames,
                         Array<double, DIM> a_dx,
-                        const AMRData<T, C, MEM, CTR>& a_data,
+                        const AMRData<T, C, DEVICE, CTR>& a_data,
+                        std::string a_filename,
+                        Args... a_params);
+        
+        /// Write AMR Hierarchy 
+        template<typename T, unsigned int C, Centering CTR, typename... Args>
+        inline void writeAMRData(
+                        std::vector<std::string> a_varnames,
+                        Array<double, DIM> a_dx,
+                        const AMRData<T, C, HOST, CTR>& a_data,
                         std::string a_filename,
                         Args... a_params);
         

--- a/include/base/implem/Proto_DisjointBoxLayoutImplem.H
+++ b/include/base/implem/Proto_DisjointBoxLayoutImplem.H
@@ -40,11 +40,16 @@ void DisjointBoxLayout::define(
 }
 
 // Copy Constructor
-DisjointBoxLayout::DisjointBoxLayout(const DisjointBoxLayout& a_input)
+DisjointBoxLayout::DisjointBoxLayout(const DisjointBoxLayout& a_input, const bool dev)
 {
-    m_partition = a_input.m_partition;
     m_problemDomain = a_input.m_problemDomain;
     m_boxSize = a_input.m_boxSize;
+    if (dev) {
+        BoxPartition* ptr = (BoxPartition*)proto_malloc<DEVICE>(sizeof(BoxPartition));
+        m_partition = std::shared_ptr<BoxPartition>{ptr};
+        proto_memcpy<HOST,DEVICE>(a_input.m_partition.get(),m_partition.get(),sizeof(BoxPartition));
+    } else
+        m_partition = a_input.m_partition;
     //m_end = a_input.m_end;
 }
 

--- a/include/base/implem/Proto_HDF5Implem.H
+++ b/include/base/implem/Proto_HDF5Implem.H
@@ -371,11 +371,32 @@ void HDF5Handler::writeAMRData(
     writeAMRData(varnames, a_dx, a_data, a_filename, a_params...);
 }
 
-template<typename T, unsigned int C, MemType MEM, Centering CTR, typename... Args>
+template<typename T, unsigned int C, Centering CTR, typename... Args>
 void HDF5Handler::writeAMRData(
         std::vector<std::string> a_varNames,
         Array<double, DIM> a_dx,
-        const AMRData<T, C, MEM, CTR>& a_data,
+        const AMRData<T, C, DEVICE, CTR>& a_data,
+        std::string a_filename,
+        Args... a_params)
+{
+    AMRData<T, C, HOST, CTR> tmp(a_data.grid(), a_data.ghost());
+    // the loop is here because we don't want the automatic ghost cell
+    // exchanging that LevelBoxData::copyTo does
+    for (int ii=0; ii < a_data.data().size(); ii++)
+    {
+        auto& data_i = a_data.data()[ii];
+        auto& temp_i = tmp.data()[ii];
+        data_i->copyTo(*temp_i);
+    }
+    //a_data.copyTo(tmp);
+    writeAMRData(a_varNames, a_dx, tmp, a_filename, a_params...);
+}
+
+template<typename T, unsigned int C, Centering CTR, typename... Args>
+void HDF5Handler::writeAMRData(
+        std::vector<std::string> a_varNames,
+        Array<double, DIM> a_dx,
+        const AMRData<T, C, HOST, CTR>& a_data,
         std::string a_filename,
         Args... a_params)
 {

--- a/include/base/implem/Proto_LevelBoxDataImplem.H
+++ b/include/base/implem/Proto_LevelBoxDataImplem.H
@@ -66,7 +66,10 @@ void LevelBoxData<T, C, MEM, CTR>::define(
 {
     m_isDefined = true;
     m_ghost = a_ghost;
-    m_layout = a_layout;
+    if (MEM==DEVICE)
+        m_layout = DisjointBoxLayout{a_layout,true};
+    else
+        m_layout = a_layout;
     m_data.resize(m_layout.localSize());
     for (auto iter : a_layout)
     {


### PR DESCRIPTION
Segfaults on Perlmutter with CUDA enabled. Here's the stack trace:

> Thread 1 "AMREuler" received signal SIGSEGV, Segmentation fault.
0x000000000043036d in __gnu_cxx::__atomic_add (__val=1, __mem=0x69)
    at /opt/cray/pe/gcc/11.2.0/snos/include/g++/ext/atomicity.h:71
71	  { __atomic_fetch_add(__mem, __val, __ATOMIC_ACQ_REL); }
(cuda-gdb) bt
#0  0x000000000043036d in __gnu_cxx::__atomic_add (__val=1, __mem=0x69)
    at /opt/cray/pe/gcc/11.2.0/snos/include/g++/ext/atomicity.h:71
#1  __gnu_cxx::__atomic_add_dispatch (__val=1, __mem=0x69) at /opt/cray/pe/gcc/11.2.0/snos/include/g++/ext/atomicity.h:111
#2  std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_add_ref_copy (this=0x61)
    at /opt/cray/pe/gcc/11.2.0/snos/include/g++/bits/shared_ptr_base.h:148
#3  0x000000000042586f in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::operator= (this=0x7fffffff4c88, __r=...)
    at /opt/cray/pe/gcc/11.2.0/snos/include/g++/bits/shared_ptr_base.h:722
#4  0x000000000041a5a1 in std::__shared_ptr<Proto::BoxPartition, (__gnu_cxx::_Lock_policy)2>::operator= (this=0x7fffffff4c80)
    at /opt/cray/pe/gcc/11.2.0/snos/include/g++/bits/shared_ptr_base.h:1153
#5  0x000000000041a5cb in std::shared_ptr<Proto::BoxPartition>::operator= (this=0x7fffffff4c80)
    at /opt/cray/pe/gcc/11.2.0/snos/include/g++/bits/shared_ptr.h:359
#6  0x000000000041a67a in Proto::DisjointBoxLayout::DisjointBoxLayout (this=0x7fffffff4c50, a_input=...)
    at /global/homes/d/dwaters/proto/include/base/implem/Proto_DisjointBoxLayoutImplem.H:45
#7  0x000000000042b6d3 in Proto::LevelBoxData<double, 5u, (Proto::MemType)2, (Proto::Centering)-1>::layout (this=0x49cf5a0)
    at /global/homes/d/dwaters/proto/include/base/Proto_LevelBoxData.H:326
#8  0x000000000044a971 in Proto::LevelBoxData<double, 5u, (Proto::MemType)2, (Proto::Centering)-1>::copyTo<(Proto::MemType)1> (
    this=0x49cf5a0, a_dest=...) at /global/homes/d/dwaters/proto/include/base/implem/Proto_LevelBoxDataImplem.H:346
#9  0x0000000000439d43 in Proto::HDF5Handler::writeAMRData<double, 5u, (Proto::Centering)-1> (this=0x7fffffff57b0, 
    a_varNames=..., a_dx=..., a_data=..., a_filename=...)
    at /global/homes/d/dwaters/proto/include/base/implem/Proto_HDF5Implem.H:389
#10 0x000000000042b44d in Proto::HDF5Handler::writeAMRData<double, 5u, (Proto::MemType)2, (Proto::Centering)-1> (
    this=0x7fffffff57b0, a_dx=..., a_data=..., a_filename=...)
    at /global/homes/d/dwaters/proto/include/base/implem/Proto_HDF5Implem.H:371
#11 0x000000000040b244 in main (argc=1, argv=0x7fffffff61b8)
    at /global/homes/d/dwaters/proto/examples/AMREuler/exec/main.cpp:199